### PR TITLE
osc.lua: fix mute icon not updating while paused

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2738,6 +2738,7 @@ end)
 
 mp.observe_property("display-fps", "number", set_tick_delay)
 mp.observe_property("pause", "bool", pause_state)
+mp.observe_property("mute", "bool", request_tick)
 mp.observe_property("demuxer-cache-state", "native", cache_state)
 mp.observe_property("vo-configured", "bool", request_tick)
 mp.observe_property("playback-time", "number", request_tick)


### PR DESCRIPTION
The mute icon in the OSC did not update if mute was toggled
while playback was paused and the mouse was idle. This happened
because no OSC redraw was triggered when the mute property changed.

This commit adds a mute observer to request_tick(), ensuring
the OSC updates immediately when mute is toggled, even if paused
and idle.